### PR TITLE
🐛 Fix: pusher update hell

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "next": "14.0.1",
     "next-auth": "^5.0.0-beta.3",
     "pg": "^8.11.3",
-    "pusher": "^5.1.3",
+    "pusher": "^5.2.0",
     "pusher-js": "^8.3.0",
     "react": "^18",
     "react-dom": "^18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,10 +3068,10 @@ pusher-js@^8.3.0:
   dependencies:
     tweetnacl "^1.0.3"
 
-pusher@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/pusher/-/pusher-5.1.3.tgz#c6b8e67f53a69dd1af344aab2571eb36fbce2a28"
-  integrity sha512-Bmy5guFxQsbYSFLF3CM7GA2qE1zDJYn51PnNme9QlSjGguvkqUg4nj31PbgiLVDFK2sJvxPfx4JrB2HLgM3kaw==
+pusher@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/pusher/-/pusher-5.2.0.tgz#cc208d15000f8d4d8b485acb844d7557adb2cf20"
+  integrity sha512-F6LNiZyJsIkoHLz+YurjKZ1HH8V1/cMggn4k97kihjP3uTvm0P4mZzSFeHOWIy+PlJ2VInJBhUFJBYLsFR5cjg==
   dependencies:
     "@types/node-fetch" "^2.5.7"
     abort-controller "^3.0.0"


### PR DESCRIPTION
This PR fixes the bug whereby editing the title or content when multiple windows view the same document results in indefinite pusher event loops.
The bug fix is in `src/hooks/useDocument.ts`. Please see my comments there for the explanation of the fixes.